### PR TITLE
Fix package name for deb dependency on stoqdrivers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Replaces: stoqlib (<< 1.0), stoq-docs (<< 1.0), stoqdoc (<< 1.0)
 Breaks: stoqlib (<< 1.0)
 Depends: ${misc:Depends}, ${python:Depends},
  python-gtk2 (>= 2.20), python-zope.interface (>= 3.5.2) | python-zopeinterface (>= 3.2.1),
- python-kiwi (>= 1.9.39), python-psycopg2 (>= 2.0.5), stoqdrivers (>= 1:0.9.19),
+ python-kiwi (>= 1.9.39), python-psycopg2 (>= 2.0.5), python-stoqdrivers (>= 1:0.9.19),
  python-imaging (>= 1.1.5), python-reportlab (>= 2.4), postgresql-client, python-dateutil (>= 1.4.1),
  python-mako (>= 0.2.5), python-gudev, python-poppler (>= 0.12.1), python-webkit (>= 1.1.7),
  python-twisted-core (>= 10.0.0), python-twisted-web (>= 10.0.0), librsvg2-common,


### PR DESCRIPTION
It should be python-stoqdrivers instead of stoqdrivers.
