### PR TITLE
ignore gedit backup files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .#*#
 #*#
 *.pyc
+*~
 
 .coverage
 .noseids


### PR DESCRIPTION
I'm using gedit in xubuntu to code, and it generates backup files ending with '~' which should be ignored by git.